### PR TITLE
Add in/output declarations to fix template error

### DIFF
--- a/src/date-time/material-date-time.component.ts
+++ b/src/date-time/material-date-time.component.ts
@@ -27,6 +27,8 @@ const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR = new Provider(
         MdIconRegistry,
         CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR
     ]
+    inputs: ['autosave','verticalMode','defaultDate', 'hours24','minDate','maxDate','mode'],
+    outputs: ['onSave','onCancel']
 })
 export class MaterialDateTimeComponent extends DateTimeComponent {
 


### PR DESCRIPTION
With the webpack2 build process angular throws a runtime error because the inherited properties are not available. Unhandled Promise rejection: Template parse errors: Can't bind to 'autosave' since it isn't a known property of 'material-date-time'.
Fixes https://github.com/CWThomson/ng2-date-time/issues/1
